### PR TITLE
Bump version to 0.0.40 and add active tab border color

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/raunofreiberg/vesper"
   },
   "icon": "icon.png",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "engines": {
     "vscode": "^1.75.0"
   },

--- a/themes/Vesper-dark-color-theme.json
+++ b/themes/Vesper-dark-color-theme.json
@@ -39,6 +39,7 @@
     // Tab
     "tab.border": "#101010",
     "tab.activeBackground": "#161616",
+    "tab.activeBorder": "#FFC799",
     "tab.inactiveBackground": "#101010",
     // Status bar
     "statusBar.debuggingForeground": "#FFF",


### PR DESCRIPTION
I really like this theme, but it was driving me a bit crazy that I couldn't easily see which one is the active tab/file, the text color difference wasn't enough, so I added the border that my previous and other themes use:

Before:
![Screenshot 2025-01-16 at 09 58 18@2x](https://github.com/user-attachments/assets/984953a8-ff01-4012-9229-86a5e0ed22f9)

After:
![Screenshot 2025-01-16 at 09 59 55@2x](https://github.com/user-attachments/assets/570439f7-22b9-46a5-96fb-0f7daf262d37)

Let me know what you think.