### PR TITLE
Add Ports section with JetBrains IDE port

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ Peppermint and orange flavored dark theme for VSCode.
 <a href="https://marketplace.visualstudio.com/items?itemName=raunofreiberg.vesper"><strong>Install →</strong></a>
 
 > Disclaimer: This was hacked together following a tutorial. I have zero experience building themes. Made for personal usage. Not thoroughly tested at all, might have broken edge cases.
+
+## Ports
+
+- [JetBrains](https://github.com/woosal1337/vesper-intellij) — IntelliJ, PyCharm, WebStorm, and other JetBrains IDEs


### PR DESCRIPTION
Adds a **Ports** section to the README listing the community JetBrains port.

The [JetBrains plugin](https://github.com/woosal1337/vesper-intellij) is a 1:1 port of Vesper that works across IntelliJ IDEA, PyCharm, WebStorm, and all other JetBrains IDEs (build 231+). It is published on the [JetBrains Marketplace](https://plugins.jetbrains.com/) and MIT-licensed.

This section is structured so other community ports can be added over time.